### PR TITLE
Fix 'loadinfrastructure' condition adding to infra without 'eid-field…

### DIFF
--- a/geotrek/infrastructure/management/commands/loadinfrastructure.py
+++ b/geotrek/infrastructure/management/commands/loadinfrastructure.py
@@ -232,6 +232,8 @@ class Command(BaseCommand):
                     self.stdout.write("Update : %s with eid %s" % (name, eid))
             else:
                 infra = Infrastructure.objects.create(**fields_without_eid)
+                if condition_type:
+                    infra.conditions.add(condition_type)
         if settings.TREKKING_TOPOLOGY_ENABLED:
             try:
                 geometry.coord_dim = 2


### PR DESCRIPTION
If '--confition-field' is used with 'loadinfrastructure', add condition to infra even if option '--eid-field' is not used.
#4328